### PR TITLE
Optimize load to snowflake process

### DIFF
--- a/target_snowflake/file_formats/csv.py
+++ b/target_snowflake/file_formats/csv.py
@@ -11,6 +11,7 @@ from target_snowflake import flattening
 
 def create_copy_sql(table_name: str,
                     stage_name: str,
+                    s3_prefix: str,
                     s3_key: str,
                     file_format_name: str,
                     columns: List):
@@ -18,13 +19,15 @@ def create_copy_sql(table_name: str,
     p_columns = ', '.join([c['name'] for c in columns])
 
     return f"COPY INTO {table_name} ({p_columns}) " \
-           f"FROM '@{stage_name}/{s3_key}' " \
+           f"FROM '@{stage_name}/{s3_prefix}' " \
+           f"PATTERN = '{s3_key}' " \
            f"ON_ERROR = CONTINUE " \
            f"FILE_FORMAT = (format_name='{file_format_name}')"
 
 
 def create_merge_sql(table_name: str,
                      stage_name: str,
+                     s3_prefix: str,
                      s3_key: str,
                      file_format_name: str,
                      columns: List,
@@ -37,8 +40,8 @@ def create_merge_sql(table_name: str,
 
     return f"MERGE INTO {table_name} t USING (" \
            f"SELECT {p_source_columns} " \
-           f"FROM '@{stage_name}/{s3_key}' " \
-           f"(FILE_FORMAT => '{file_format_name}')) s " \
+           f"FROM '@{stage_name}/{s3_prefix}' " \
+           f"(FILE_FORMAT => '{file_format_name}'), PATTERN => '{s3_key}') s " \
            f"ON {pk_merge_condition} " \
            f"WHEN MATCHED THEN UPDATE SET {p_update} " \
            "WHEN NOT MATCHED THEN " \


### PR DESCRIPTION
What                  | Where/Who
----------------------|----------------------------------------
Reviewers             | @pslavov @nezd  @ivanovyordan 

## Background and why
   
While reading replication data from postgres just create s3 files and
do not load them in snowflake. When the replication is finished load all
files for each table at once  - this way will limit import calls to
snowflake and import bigger batches - which is always better in
snowflake.
Also files will not be deleted when they are loaded, but we will keep
them in s3 for a week - cleaned later using lifecycle

Also update the S3 prefix to include hour and minutes - to avoid having
data imported multiple times when we have same pid in the same day.
