### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,6 +6,9 @@ on:
     branches:
       - master
 
+permissions:
+  contents: read
+
 jobs:
   lint_and_test:
     name: Linting and Testing

--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -4,6 +4,9 @@ on:
   release:
     types: [created]
 
+permissions:
+  contents: read
+
 jobs:
   deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/dext/pipelinewise-target-snowflake/security/code-scanning/3](https://github.com/dext/pipelinewise-target-snowflake/security/code-scanning/3)

To fix the issue, we will add a `permissions` block to the workflow. This block will explicitly define the minimal permissions required for the workflow to function. Since the workflow primarily involves checking out the repository, setting up Python, and running tests, it only requires `contents: read` permissions. We will add this `permissions` block at the root level of the workflow to apply it to all jobs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
